### PR TITLE
Refactor functions to use new helper

### DIFF
--- a/src/dos_tests/file.rs
+++ b/src/dos_tests/file.rs
@@ -36,5 +36,4 @@ pub(crate) fn directory_test() {
     print!("Deleting folder {path}... ");
     dos::file::Directory::remove(path).unwrap();
     println!("Done");
-
 }


### PR DESCRIPTION
Changed `File::open()` and `File::attributes()` to make use of the new `file_folder_helper()` function. Extended that function to support getting the return value from either ax or cx registers.
